### PR TITLE
Dockerfile: enable SCL packages in Docker environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,14 @@ version: 2
 jobs:
   build:
     docker:
-      - image: iqlusion/rust-ci:201804060 # bump cache keys when modifying this
+      - image: iqlusion/rust-ci:201804061 # bump cache keys when modifying this
     environment:
       - PROJECTS=rpmlib-sys tai64
 
     steps:
       - checkout
       - restore_cache:
-          key: cache-201804060 # bump save_cache key below too
+          key: cache-201804061 # bump save_cache key below too
       - run:
           name: rustfmt
           command: |
@@ -36,8 +36,8 @@ jobs:
             rustc --version
             cargo --version
             cd rpmlib-sys
-            scl enable llvm-toolset-7 "cargo build"
-            scl enable llvm-toolset-7 "cargo test"
+            cargo build
+            cargo test
       - run:
           name: "tai64 crate (build, test)"
           command: |
@@ -48,7 +48,7 @@ jobs:
             cargo test
             cargo test --features=chrono
       - save_cache:
-          key: cache-201804060 # bump restore_cache key above too
+          key: cache-201804061 # bump restore_cache key above too
           paths:
             - "~/.cargo"
             - "./target"

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,3 +39,9 @@ RUN rustup run $RUST_NIGHTLY_VERSION cargo install rustfmt-nightly --vers $RUSTF
 
 ENV CLIPPY_VERSION "0.0.192"
 RUN rustup run $RUST_NIGHTLY_VERSION cargo install clippy --vers $CLIPPY_VERSION --force
+
+# Set environment variables to enable SCL packages (llvm-toolset-7)
+ENV LD_LIBRARY_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64
+ENV PATH "/opt/rh/llvm-toolset-7/root/usr/bin:/opt/rh/llvm-toolset-7/root/usr/sbin:$PATH"
+ENV PKG_CONFIG_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64/pkgconfig
+ENV X_SCLS llvm-toolset-7


### PR DESCRIPTION
I haven't found a good way to use `scl-source enable` inside of Docker, but this should mimick the effect and eliminate the need to manually enable SCL.