### PR TITLE
rpmlib: Basic wrapper for rpmts

### DIFF
--- a/rpmlib/Cargo.toml
+++ b/rpmlib/Cargo.toml
@@ -14,7 +14,7 @@ repository  = "https://github.com/iqlusion-io/crates/tree/master/rpmlib"
 circle-ci = { repository = "iqlusion-io/crates" }
 
 [dependencies]
-rpmlib-sys = { version = "0", path = "../rpmlib-sys", optional = true }
+rpmlib-sys = { version = "0.2", path = "../rpmlib-sys", optional = true }
 
 # Allow building without rpmlib-sys so we can e.g. use docs.rs for rendering
 # documentation for this crate

--- a/rpmlib/src/lib.rs
+++ b/rpmlib/src/lib.rs
@@ -14,3 +14,10 @@
 
 #[cfg(feature = "rpmlib-sys")]
 extern crate rpmlib_sys;
+
+mod txnset;
+
+pub use txnset::TxnSet;
+
+/// A shorter alias for TxnSet
+pub type Txn = TxnSet;

--- a/rpmlib/src/txnset.rs
+++ b/rpmlib/src/txnset.rs
@@ -1,0 +1,48 @@
+//! txnset: transaction sets (a.k.a. rpmts)
+//!
+//! Nearly all access to rpmlib, including actions which don't necessarily
+//! involve operations on the RPM database, require a transaction set.
+
+#[cfg(feature = "rpmlib-sys")]
+use rpmlib_sys::{rpmts, rpmtsCreate, rpmtsFree};
+
+/// Transactions within rpmlib over the RPM database and other functionality
+pub struct TxnSet {
+    /// rpmlib's transaction set type (or more specifically, a mut pointer)
+    #[cfg(feature = "rpmlib-sys")]
+    ts: rpmts,
+}
+
+impl TxnSet {
+    /// Create a new transaction
+    #[inline]
+    pub fn create() -> Self {
+        #[cfg(not(feature = "rpmlib-sys"))]
+        panic!("rpmlib not available");
+
+        #[cfg(feature = "rpmlib-sys")]
+        Self {
+            ts: unsafe { rpmtsCreate() },
+        }
+    }
+}
+
+#[cfg(feature = "rpmlib-sys")]
+impl Drop for TxnSet {
+    fn drop(&mut self) {
+        unsafe {
+            rpmtsFree(self.ts);
+        }
+    }
+}
+
+#[cfg(all(test, feature = "rpmlib-sys"))]
+mod tests {
+    use super::TxnSet;
+
+    #[test]
+    fn create_test() {
+        // Does create work at all?
+        TxnSet::create();
+    }
+}


### PR DESCRIPTION
Initial support for creating transaction sets (with implicit `Drop`-based destructor)