### PR TITLE
Dockerfile: Set RUSTFLAGS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: iqlusion/rust-ci:201804061 # bump cache keys when modifying this
+      - image: iqlusion/rust-ci:201804090 # bump cache keys when modifying this
 
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@
 
 FROM centos:7.4.1708
 
+# Include cargo in the path
 ENV PATH "$PATH:/root/.cargo/bin"
 
 # Install/update RPMs
@@ -45,3 +46,6 @@ ENV LD_LIBRARY_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64
 ENV PATH "/opt/rh/llvm-toolset-7/root/usr/bin:/opt/rh/llvm-toolset-7/root/usr/sbin:$PATH"
 ENV PKG_CONFIG_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64/pkgconfig
 ENV X_SCLS llvm-toolset-7
+
+# Configure RUSTFLAGS
+ENV RUSTFLAGS "-Ctarget-feature=+aes"


### PR DESCRIPTION
These flags enable the `core::arch` AES-NI instructions on x86-64 CPUs.