### PR TITLE
rpmlib-sys: Use cargo features to control binding/linking rpmbuild + rpmsign

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
           command: |
             rustc --version
             cargo --version
+            (cd rpmlib-sys && cargo test --features=rpmbuild,rpmsign)
             (cd tai64 && cargo test --features=chrono)
       - save_cache:
           key: cache-201804090 # bump restore_cache key above too

--- a/rpmlib-sys/Cargo.toml
+++ b/rpmlib-sys/Cargo.toml
@@ -15,3 +15,8 @@ circle-ci = { repository = "iqlusion-io/crates" }
 
 [build-dependencies]
 bindgen = "0.35"
+
+[features]
+default = []
+rpmbuild = []
+rpmsign = []

--- a/rpmlib-sys/include/rpmbuild.hpp
+++ b/rpmlib-sys/include/rpmbuild.hpp
@@ -1,0 +1,5 @@
+// rpmbuild.hpp: Wrapper for rpmlib header files to be passed to bindgen
+
+/** librpmbuild headers */
+#include <rpm/rpmbuild.h>
+#include <rpm/rpmspec.h>

--- a/rpmlib-sys/include/rpmlib.hpp
+++ b/rpmlib-sys/include/rpmlib.hpp
@@ -1,4 +1,4 @@
-// rpmlib-sys.hpp: Wrapper for rpmlib header files to be passed to bindgen
+// rpmlib.hpp: Wrapper for rpmlib header files to be passed to bindgen
 //
 // See "Using the RPM Library" section of "Chapter 15. Programming RPM with C"
 // of the Fedora RPM Guide (Draft 0.1):
@@ -46,10 +46,3 @@
 #include <rpm/rpmds.h> // Dependency sets
 #include <rpm/rpmfi.h> // File information
 #include <rpm/header.h> // Package headers
-
-/** librpmbuild headers */
-#include <rpm/rpmbuild.h>
-#include <rpm/rpmspec.h>
-
-/** librpmsign headers */
-#include <rpm/rpmsign.h>

--- a/rpmlib-sys/include/rpmsign.hpp
+++ b/rpmlib-sys/include/rpmsign.hpp
@@ -1,0 +1,4 @@
+// rpmsign.hpp: Wrapper for rpmlib header files to be passed to bindgen
+
+/** librpmsign headers */
+#include <rpm/rpmsign.h>

--- a/rpmlib-sys/src/lib.rs
+++ b/rpmlib-sys/src/lib.rs
@@ -9,65 +9,87 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+/// Bindings to librpm.so and librpmio.so
+pub mod rpmlib {
+    use hax::timex;
+    include!(concat!(env!("OUT_DIR"), "/rpmlib_binding.rs"));
+}
 
-// WARNING: potentially unsafe hax ahead!
-//
-// `struct timex` (defined manually below) is problematic because the bindgen
-// version includes a 352-bit bitfield type for `_bitfield_1`:
-//
-//     __BindgenBitfieldUnit<[u8; 44], u8>
-//
-// bindgen bounds the traits of the generic storage type for its bitfield units
-// on `AsRef` and `AsMut`, which do not have blanket impls for `[T; N]` where
-// N > 32.
-//
-// To work around the problem, we blacklist the type in `build.rs`, and include
-// a (hopefully) equivalent one which actually compiles, namely by removing the
-// `__BindgenBitfieldUnit` wraper around `[u8; 44]`, which should hopefully
-// (???)
-// result in an equivalent-sized type.
-//
-// `struct timex` is used only one place in the generated binding: as a
-// parameter to `clock_adjtime`:
-//
-//     extern "C" {
-//         pub fn clock_adjtime(
-//             __clock_id: __clockid_t,
-//            __utx: *mut timex
-//         ) -> ::std::os::raw::c_int;
-//     }
-//
-// If we could blacklist `clock_adjtime` from the binding, we wouldn't need this
-// manually tweaked copy-and-paste definition of `struct timex`.
-//
-// Ideally we should probably switch to using `whitelisted_functions` and only
-// include functions we actually intend to bind in the binding.
-//
-// Context:
-// - https://github.com/iqlusion-io/crates/issues/11
-// - https://github.com/iqlusion-io/crates/issues/12
-#[repr(C)]
-pub struct timex {
-    pub modes: ::std::os::raw::c_uint,
-    pub offset: __syscall_slong_t,
-    pub freq: __syscall_slong_t,
-    pub maxerror: __syscall_slong_t,
-    pub esterror: __syscall_slong_t,
-    pub status: ::std::os::raw::c_int,
-    pub constant: __syscall_slong_t,
-    pub precision: __syscall_slong_t,
-    pub tolerance: __syscall_slong_t,
-    pub time: timeval,
-    pub tick: __syscall_slong_t,
-    pub ppsfreq: __syscall_slong_t,
-    pub jitter: __syscall_slong_t,
-    pub shift: ::std::os::raw::c_int,
-    pub stabil: __syscall_slong_t,
-    pub jitcnt: __syscall_slong_t,
-    pub calcnt: __syscall_slong_t,
-    pub errcnt: __syscall_slong_t,
-    pub stbcnt: __syscall_slong_t,
-    pub tai: ::std::os::raw::c_int,
-    pub _bitfield_1: [u8; 44], // Was: `__BindgenBitfieldUnit<[u8; 44], u8>`
+/// Bindings to librpmbuild.so
+#[cfg(feature = "rpmbuild")]
+pub mod rpmbuild {
+    use hax::timex;
+    include!(concat!(env!("OUT_DIR"), "/rpmbuild_binding.rs"));
+}
+
+/// Bindings to librpmsign.so
+#[cfg(feature = "rpmsign")]
+pub mod rpmsign {
+    include!(concat!(env!("OUT_DIR"), "/rpmsign_binding.rs"));
+}
+
+// Hacks needed to get the current binding to compile
+// TODO: whitelist functions we need so `clock_adjtime` isn't in the binding
+mod hax {
+    use rpmlib::{__syscall_slong_t, timeval};
+
+    // WARNING: potentially unsafe hax ahead!
+    //
+    // `struct timex` (defined manually below) is problematic because the bindgen
+    // version includes a 352-bit bitfield type for `_bitfield_1`:
+    //
+    //     __BindgenBitfieldUnit<[u8; 44], u8>
+    //
+    // bindgen bounds the traits of the generic storage type for its bitfield
+    // units on `AsRef` and `AsMut`, which do not have blanket impls for `[T; N]`
+    // where N > 32.
+    //
+    // To work around the problem, we blacklist the type in `build.rs`, and
+    // include a (hopefully) equivalent one which actually compiles, namely by
+    // removing the `__BindgenBitfieldUnit` wraper around `[u8; 44]`, which
+    // should hopefully(???) result in an equivalent-sized type.
+    //
+    // `struct timex` is used only one place in the generated binding: as a
+    // parameter to `clock_adjtime`:
+    //
+    //     extern "C" {
+    //         pub fn clock_adjtime(
+    //             __clock_id: __clockid_t,
+    //            __utx: *mut timex
+    //         ) -> ::std::os::raw::c_int;
+    //     }
+    //
+    // If we could blacklist `clock_adjtime` from the binding, we wouldn't need this
+    // manually tweaked copy-and-paste definition of `struct timex`.
+    //
+    // Ideally we should probably switch to using `whitelisted_functions` and only
+    // include functions we actually intend to bind in the binding.
+    //
+    // Context:
+    // - https://github.com/iqlusion-io/crates/issues/11
+    // - https://github.com/iqlusion-io/crates/issues/12
+    #[repr(C)]
+    pub struct timex {
+        pub modes: ::std::os::raw::c_uint,
+        pub offset: __syscall_slong_t,
+        pub freq: __syscall_slong_t,
+        pub maxerror: __syscall_slong_t,
+        pub esterror: __syscall_slong_t,
+        pub status: ::std::os::raw::c_int,
+        pub constant: __syscall_slong_t,
+        pub precision: __syscall_slong_t,
+        pub tolerance: __syscall_slong_t,
+        pub time: timeval,
+        pub tick: __syscall_slong_t,
+        pub ppsfreq: __syscall_slong_t,
+        pub jitter: __syscall_slong_t,
+        pub shift: ::std::os::raw::c_int,
+        pub stabil: __syscall_slong_t,
+        pub jitcnt: __syscall_slong_t,
+        pub calcnt: __syscall_slong_t,
+        pub errcnt: __syscall_slong_t,
+        pub stbcnt: __syscall_slong_t,
+        pub tai: ::std::os::raw::c_int,
+        pub _bitfield_1: [u8; 44], // Was: `__BindgenBitfieldUnit<[u8; 44], u8>`
+    }
 }

--- a/rpmlib/src/txnset.rs
+++ b/rpmlib/src/txnset.rs
@@ -4,7 +4,7 @@
 //! involve operations on the RPM database, require a transaction set.
 
 #[cfg(feature = "rpmlib-sys")]
-use rpmlib_sys::{rpmts, rpmtsCreate, rpmtsFree};
+use rpmlib_sys::rpmlib::{rpmts, rpmtsCreate, rpmtsFree};
 
 /// Transactions within rpmlib over the RPM database and other functionality
 pub struct TxnSet {


### PR DESCRIPTION
It's unlikely anyone will actually use either of these in the near future, but it's also nice we're successfully generating bindings for them.

Gate both of them on optional cargo features which have to be opted into. That way we don't waste time running bindgen on them unless people actually care, but in CI we can ensure we can still produce bindings for them.