### PR TITLE
rpmlib: Track mutable global state in GlobalState struct

### DIFF
--- a/rpmlib/src/global_state.rs
+++ b/rpmlib/src/global_state.rs
@@ -1,0 +1,33 @@
+//! Thread-safe tracking struct for RPM's global mutable state
+//!
+//! rpmlib has a lot of global mutable state, and depending on what state it
+//! is in various calls are safe (or not).
+//!
+//! This struct tracks changes to rpmlib's global state based on functions we
+//! have (or have not) invoked.
+
+use std::sync::{Mutex, MutexGuard};
+
+lazy_static! {
+    static ref RPM_GLOBAL_STATE: Mutex<GlobalState> = Mutex::new(GlobalState::default());
+}
+
+/// Tracking struct for mutable global state in RPM
+pub(crate) struct GlobalState {
+    /// Have any configuration functions been called? (Specifically any ones
+    /// which invoke `rpmInitCrypto`, which it seems should only be called once)
+    pub configured: bool,
+}
+
+impl Default for GlobalState {
+    fn default() -> GlobalState {
+        GlobalState { configured: false }
+    }
+}
+
+impl GlobalState {
+    /// Obtain an exclusive lock to the global state
+    pub fn lock() -> MutexGuard<'static, Self> {
+        RPM_GLOBAL_STATE.lock().unwrap()
+    }
+}

--- a/rpmlib/src/lib.rs
+++ b/rpmlib/src/lib.rs
@@ -38,6 +38,9 @@ pub mod header;
 /// Wrapper for rpmlib which ensures single-threaded access
 mod ffi;
 
+/// RPM's global state
+mod global_state;
+
 /// Macros are RPM's configuration system
 pub mod macro_context;
 
@@ -52,6 +55,7 @@ pub mod tag;
 
 pub use db::Database;
 pub use header::Header;
+pub(crate) use global_state::GlobalState;
 pub use macro_context::MacroContext;
 pub use streaming_iterator::StreamingIterator;
 pub use td::TagData;


### PR DESCRIPTION
Adds a static mutex-locked struct for tracking rpmlib's global mutable state