### PR TITLE
cargo-rpm: Initial crate with "cargo rpm init" command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-rpm"
+version = "0.0.0"
+dependencies = [
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gumdrop 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gumdrop_derive 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "handlebars 1.0.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iq-cli 0.0.0",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +145,11 @@ dependencies = [
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "dtoa"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "env_logger"
@@ -182,6 +202,38 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "gumdrop"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gumdrop_derive 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gumdrop_derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "handlebars"
+version = "1.0.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest_derive 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "humantime"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +248,11 @@ dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
@@ -267,6 +324,29 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "pest"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pest_derive"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pest 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +365,14 @@ dependencies = [
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand"
@@ -361,6 +449,42 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +497,16 @@ dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -455,6 +589,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ucd-util"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +609,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -542,13 +689,18 @@ dependencies = [
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
 "checksum clang-sys 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "939a1a34310b120d26eba35c29475933128b0ec58e24b43327f8dbe6036fc538"
 "checksum clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f16b89cbb9ee36d87483dc939fe9f1e13c05898d56d7b230a0d4dff033a536"
+"checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum env_logger 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0f475037312b91d34dbc3142a1ad3980ef0d070c7a855ce238afdd5e987cfecc"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
 "checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum gumdrop 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b776c41038e3c3b6b2fb188cfda9282b3caed6b964749836ce1a763a8e0b9449"
+"checksum gumdrop_derive 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d51865073dd492ad5b545835557c854dbdf826f72c5ca343d1c3a6ab71185e30"
+"checksum handlebars 1.0.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5318857c4f09fcf07dd8cbb3169f0e48f1cd488397ec9f3239c89a6d3162efd2"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
+"checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
@@ -559,9 +711,13 @@ dependencies = [
 "checksum num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f8d26da319fb45674985c78f1d1caf99aa4941f785d384a2ae36d0740bc3e2fe"
 "checksum num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dee092fcdf725aee04dd7da1d21debff559237d49ef1cb3e69bcb8ece44c7364"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+"checksum pest 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0fce5d8b5cc33983fc74f78ad552b5522ab41442c4ca91606e4236eb4b5ceefc"
+"checksum pest_derive 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ab94faafeb93f4c5e3ce81ca0e5a779529a602ad5d09ae6d21996bfb8b6a52bf"
+"checksum proc-macro2 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "49b6a521dc81b643e9a51e0d1cf05df46d5a2f3c0280ea72bcb68276ba64a118"
 "checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
 "checksum quickcheck 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c01babc5ffd48a2a83744b3024814bb46dfd4f2a4705ccb44b1b60e644fdcab7"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum quote 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7b0ff51282f28dc1b53fd154298feaa2e77c5ea0dba68e1fd8b03b72fbe13d2a"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
@@ -569,8 +725,13 @@ dependencies = [
 "checksum regex-syntax 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bd90079345f4a4c3409214734ae220fd773c6f2e8a543d07370c6c1c369cfbfb"
 "checksum remove_dir_all 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dfc5b3ce5d5ea144bb04ebd093a9e14e9765bcfec866aecda9b6dec43b3d1e24"
 "checksum rustc-demangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11fb43a206a04116ffd7cfcf9bcb941f8eb6cc7ff667272246b0a1c74259a3cb"
+"checksum serde 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "4c36359ac1a823e00db02a243376ced650f088dc1f6259bbf828e4668e3c7399"
+"checksum serde_derive 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "f0477feff739386f5bca8e13fa43d96a4e834904d538f503906c8179f9205f50"
+"checksum serde_derive_internals 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9d30c4596450fd7bbda79ef15559683f9a79ac0193ea819db90000d7e1cae794"
+"checksum serde_json 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "8f6f1f77b969caa064f347544d703efacaf4854b84831096a5dc206a8aedbc27"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "91b52877572087400e83d24b9178488541e3d535259e04ff17a63df1e5ceff59"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
@@ -579,9 +740,11 @@ dependencies = [
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
+"checksum toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a0263c6c02c4db6c8f7681f9fd35e90de799ebd4cfdeab77a38f4ff6b3d8c0d9"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "canonical-path",
+    "cargo-rpm",
     "iq-cli",
     "rpmlib",
     "rpmlib-sys",

--- a/cargo-rpm/.rpm/cargo-rpm.spec
+++ b/cargo-rpm/.rpm/cargo-rpm.spec
@@ -1,0 +1,40 @@
+%define __spec_install_post %{nil}
+%define __os_install_post %{_dbpath}/brp-compress
+%define debug_package %{nil}
+
+Name: cargo-rpm
+Summary: Build RPMs from Rust projects using Cargo
+Version: @@VERSION@@ # Set automatically by "cargo rpm build"
+Release: 1
+License: ASL 2.0
+Group: Applications/System
+Source0: %{name}-%{version}.tar.gz
+URL: https://github.com/iqlusion-io/crates/
+
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+
+%description
+%{summary}
+
+%prep
+%setup -q
+
+%build
+# Empty section.
+
+%install
+rm -rf %{buildroot}
+mkdir -p  %{buildroot}
+
+# in builddir
+cp -a * %{buildroot}
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%config(noreplace) %{_sysconfdir}/*
+${_bindir}/*
+%{_sbindir}/*
+

--- a/cargo-rpm/Cargo.toml
+++ b/cargo-rpm/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name        = "cargo-rpm"
+description = "Build RPMs from Rust projects using Cargo"
+version     = "0.0.0" # Also update html_root_url in lib.rs when bumping this
+authors     = ["Tony Arcieri <tony@iqlusion.io>"]
+license     = "Apache-2.0"
+homepage    = "https://github.com/iqlusion-io/crates/"
+repository  = "https://github.com/iqlusion-io/crates/tree/master/cargo-rpm"
+readme      = "README.md"
+categories  = ["command-line-utilities", "development-tools"]
+keywords    = ["rpm", "cargo", "package", "release"]
+
+[dependencies]
+failure = "0.1"
+gumdrop = "0.4"
+gumdrop_derive = "0.4"
+handlebars = "1.0.0-beta.1"
+iq-cli = { version = "0", path = "../iq-cli" }
+lazy_static = "1"
+serde = "1"
+serde_derive = "1"
+toml = "0.4"
+
+[package.metadata.rpm.target]
+cargo-rpm = { path = "/usr/bin/cargo-rpm" }

--- a/cargo-rpm/src/cargo_config.rs
+++ b/cargo-rpm/src/cargo_config.rs
@@ -1,0 +1,86 @@
+//! Cargo.toml parser specialized for the `cargo rpm` use case
+
+use failure::Error;
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use toml;
+
+/// Struct representing a `Cargo.toml` file
+#[derive(Debug, Deserialize)]
+pub struct CargoConfig {
+    /// Cargo package configuration
+    pub package: PackageConfig,
+}
+
+/// Struct representing a `Cargo.toml` file's `[package]` section
+#[derive(Clone, Debug, Deserialize)]
+pub struct PackageConfig {
+    /// Name of the package
+    pub name: String,
+
+    /// Description of the package
+    pub description: String,
+
+    /// Version of the package
+    pub version: String,
+
+    /// License of the package
+    pub license: Option<String>,
+
+    /// Homepage of the package
+    pub homepage: Option<String>,
+
+    /// Package metadata table
+    pub metadata: Option<PackageMetadata>,
+}
+
+impl PackageConfig {
+    /// Parse the given path (i.e. `Cargo.toml`), returning a PackageConfig struct
+    pub fn load<P>(filename: P) -> Result<PackageConfig, Error>
+    where
+        P: AsRef<Path>,
+    {
+        let mut file = File::open(filename.as_ref())?;
+        let mut data = String::new();
+        file.read_to_string(&mut data).unwrap();
+
+        let config: CargoConfig = toml::from_str(&data)
+            .map_err(|e| format_err!("error parsing {}: {}", filename.as_ref().display(), e))?;
+
+        Ok(config.package)
+    }
+
+    /// Get the RpmConfig for this package (if present)
+    pub fn rpm_metadata(&self) -> Option<&RpmConfig> {
+        match self.metadata {
+            Some(ref m) => m.rpm.as_ref(),
+            None => None,
+        }
+    }
+}
+
+/// The `[package.metadata]` table: ignored by Cargo, but we can put stuff there
+#[derive(Clone, Debug, Deserialize)]
+pub struct PackageMetadata {
+    /// Our custom RPM metadata extension to `Cargo.toml`
+    pub rpm: Option<RpmConfig>,
+}
+
+/// Our `[package.metadata.rpm]` extension to `Cargo.toml`
+#[derive(Clone, Debug, Deserialize)]
+pub struct RpmConfig {
+    /// Target configuration: a map of target binaries to their file config
+    target: BTreeMap<String, FileConfig>,
+
+    /// Extra files (taken from the `.rpm` directory) to include in the RPM
+    file: Option<BTreeMap<String, FileConfig>>,
+}
+
+/// Properties of a file to be included in the final RPM
+#[derive(Clone, Debug, Deserialize)]
+pub struct FileConfig {
+    /// Absolute path where the file should reside after installation
+    path: PathBuf,
+}

--- a/cargo-rpm/src/init.rs
+++ b/cargo-rpm/src/init.rs
@@ -1,0 +1,247 @@
+//! The `cargo rpm init` subcommand
+
+use failure::Error;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use RPM_CONFIG_DIR;
+use cargo_config::PackageConfig;
+use shell::{self, color};
+use target::TargetType;
+use templates::{ServiceParams, SpecParams};
+
+/// Name of the file containing cargo configuration. You know...
+const CARGO_CONFIG_FILE: &str = "Cargo.toml";
+
+/// Directory in which systemd service unit configs reside
+const SYSTEMD_DIR: &str = "/usr/lib/systemd/system";
+
+/// Options for the `cargo rpm init` subcommand
+#[derive(Debug, Default, Options)]
+pub struct InitOpts {
+    /// Force (re-)generation, even if .rpm exists or the target type is unsupported
+    #[options(long = "force")]
+    pub force: bool,
+
+    /// Place binaries in `/usr/sbin` instead of `/usr/bin`?
+    #[options(no_short, long = "sbin")]
+    pub sbin: bool,
+
+    /// Path to the systemd service unit config template
+    #[options(no_short, long = "service")]
+    pub service: Option<PathBuf>,
+
+    /// Configure this RPM as a systemd service unit
+    #[options(short = "s", long = "systemd")]
+    pub systemd: bool,
+
+    /// Path to the RPM spec template
+    #[options(long = "template")]
+    pub template: Option<PathBuf>,
+}
+
+impl InitOpts {
+    /// Invoke the `cargo rpm init` subcommand
+    pub fn call(&self) -> Result<(), Error> {
+        // Calculate paths relative to the current directory
+        let crate_root = PathBuf::from(".");
+        let cargo_toml = crate_root.join(CARGO_CONFIG_FILE);
+        let rpm_config_dir = crate_root.join(RPM_CONFIG_DIR);
+
+        // Read Cargo.toml
+        let package_config = PackageConfig::load(&cargo_toml)?;
+
+        // Check if `.rpm` already exists
+        if rpm_config_dir.exists() {
+            if self.force {
+                let canonical_rpm_config_dir = rpm_config_dir.canonicalize()?;
+                shell::say_status(
+                    "Deleting",
+                    format!("{} (forced)", canonical_rpm_config_dir.display()),
+                    color::YELLOW,
+                    true,
+                );
+                fs::remove_dir_all(&rpm_config_dir)?;
+            } else {
+                shell::exit_error(format!(
+                    "destination `{}` already exists!",
+                    rpm_config_dir.canonicalize().unwrap().display()
+                ));
+            }
+        }
+
+        // Check if we're creating a systemd service unit for this crate
+        let service_name = if self.service.is_some() || self.systemd {
+            Some(format!("{}.service", package_config.name))
+        } else {
+            None
+        };
+
+        // Autodetect whether to place target files in `/usr/bin` or `/usr/sbin`
+        let use_sbin = self.sbin || service_name.is_some();
+
+        // Autodetect target types
+        let targets = match TargetType::detect(&crate_root)? {
+            TargetType::Lib => {
+                if self.force {
+                    // If forced, just return an empty target list
+                    vec![]
+                } else {
+                    shell::exit_error("detected unsupported library crate (-f to override)");
+                }
+            }
+            TargetType::Bin => vec![package_config.name.clone()],
+            TargetType::MultiBin(targets) => targets,
+        };
+
+        // Create `.rpm` directory
+        fs::create_dir(&rpm_config_dir)?;
+        shell::say_status(
+            "Created",
+            rpm_config_dir.canonicalize().unwrap().display(),
+            color::GREEN,
+            true,
+        );
+
+        // Render `.rpm/<cratename>.spec`
+        let spec_path = rpm_config_dir.join(format!("{}.spec", package_config.name));
+        render_spec(&spec_path, &self.template, &package_config, &service_name)?;
+
+        // (Optional) Render `.rpm/<cratename>.service` (systemd service unit config)
+        if let Some(ref service) = service_name {
+            render_service(
+                &rpm_config_dir.join(service),
+                &self.service,
+                &package_config,
+            )?;
+        }
+
+        // Update Cargo.toml with RPM metadata
+        if package_config.rpm_metadata().is_some() && !self.force {
+            shell::warning(
+                "not updating Cargo.toml because [package.metadata.rpm] already present",
+            );
+        } else {
+            let mut extra_files = vec![];
+            if let Some(ref service) = service_name {
+                extra_files.push(PathBuf::from(SYSTEMD_DIR).join(service.clone()));
+            }
+
+            let bin_dir: PathBuf = if use_sbin { "/usr/sbin" } else { "/usr/bin" }.into();
+            update_cargo_metadata(&cargo_toml, &targets, &extra_files, &bin_dir)?;
+        }
+
+        shell::say_status(
+            "Finished",
+            format!(
+                "{} configured (type \"cargo rpm build\" to build)",
+                package_config.name
+            ),
+            color::GREEN,
+            true,
+        );
+
+        Ok(())
+    }
+}
+
+/// Render this package's RPM spec
+fn render_spec(
+    spec_path: &Path,
+    template: &Option<PathBuf>,
+    package_config: &PackageConfig,
+    service_name: &Option<String>,
+) -> Result<(), Error> {
+    let mut spec_params = SpecParams::from(package_config);
+    spec_params.service = service_name.clone();
+    let spec_rendered = spec_params.render(template.as_ref().map(|p| p.as_ref()))?;
+
+    let mut spec_file = File::create(spec_path)?;
+    spec_file.write_all(spec_rendered.as_bytes())?;
+
+    shell::say_status(
+        "Rendered",
+        spec_path.canonicalize().unwrap().display(),
+        color::GREEN,
+        true,
+    );
+
+    Ok(())
+}
+
+/// Render this package's systemd service unit config (if enabled)
+fn render_service(
+    service_path: &Path,
+    template: &Option<PathBuf>,
+    package_config: &PackageConfig,
+) -> Result<(), Error> {
+    let service_params = ServiceParams::from(package_config);
+    let service_rendered = service_params.render(template.as_ref().map(|p| p.as_ref()))?;
+
+    let mut service_file = File::create(service_path)?;
+    service_file.write_all(service_rendered.as_bytes())?;
+
+    shell::say_status(
+        "Rendered",
+        service_path.canonicalize().unwrap().display(),
+        color::GREEN,
+        true,
+    );
+
+    Ok(())
+}
+
+/// Render `package.metadata.rpm` section to include in Cargo.toml
+fn update_cargo_metadata(
+    path: &Path,
+    targets: &[String],
+    extra_files: &[PathBuf],
+    bin_dir: &Path,
+) -> Result<(), Error> {
+    assert!(!targets.is_empty(), "no target configuration?!");
+
+    shell::say_status(
+        "Updating",
+        path.canonicalize().unwrap().display(),
+        color::BRIGHT_CYAN,
+        true,
+    );
+
+    // TODO: use real serde serializer?
+    let mut cargo_toml = OpenOptions::new().append(true).open(path)?;
+    writeln!(cargo_toml, "\n[package.metadata.rpm.target]")?;
+
+    for target in targets {
+        writeln!(
+            cargo_toml,
+            "{} = {{ path = {:?} }}",
+            target,
+            bin_dir.join(target)
+        )?;
+    }
+
+    // These files come from the .rpm directory
+    if !extra_files.is_empty() {
+        writeln!(cargo_toml, "\n[package.metadata.rpm.file]")?;
+
+        for path in extra_files {
+            if !path.is_absolute() {
+                shell::exit_error(format!("path is not absolute: {}", path.display()));
+            }
+
+            let file = path.file_name().unwrap_or_else(|| {
+                shell::exit_error(format!("path has no filename: {}", path.display()));
+            });
+
+            writeln!(
+                cargo_toml,
+                "{:?} = {{ path = {:?} }}",
+                file.to_str().unwrap(),
+                path.display()
+            )?;
+        }
+    }
+
+    Ok(())
+}

--- a/cargo-rpm/src/init.rs
+++ b/cargo-rpm/src/init.rs
@@ -30,7 +30,7 @@ pub struct InitOpts {
 
     /// Path to the systemd service unit config template
     #[options(no_short, long = "service")]
-    pub service: Option<PathBuf>,
+    pub service: Option<String>,
 
     /// Configure this RPM as a systemd service unit
     #[options(short = "s", long = "systemd")]
@@ -38,7 +38,7 @@ pub struct InitOpts {
 
     /// Path to the RPM spec template
     #[options(long = "template")]
-    pub template: Option<PathBuf>,
+    pub template: Option<String>,
 }
 
 impl InitOpts {
@@ -149,13 +149,15 @@ impl InitOpts {
 /// Render this package's RPM spec
 fn render_spec(
     spec_path: &Path,
-    template: &Option<PathBuf>,
+    template_path_str: &Option<String>,
     package_config: &PackageConfig,
     service_name: &Option<String>,
 ) -> Result<(), Error> {
     let mut spec_params = SpecParams::from(package_config);
     spec_params.service = service_name.clone();
-    let spec_rendered = spec_params.render(template.as_ref().map(|p| p.as_ref()))?;
+
+    let template_path = template_path_str.as_ref().map(|t| PathBuf::from(t));
+    let spec_rendered = spec_params.render(template_path.as_ref().map(|t| t.as_ref()))?;
 
     let mut spec_file = File::create(spec_path)?;
     spec_file.write_all(spec_rendered.as_bytes())?;
@@ -173,11 +175,12 @@ fn render_spec(
 /// Render this package's systemd service unit config (if enabled)
 fn render_service(
     service_path: &Path,
-    template: &Option<PathBuf>,
+    template_path_str: &Option<String>,
     package_config: &PackageConfig,
 ) -> Result<(), Error> {
     let service_params = ServiceParams::from(package_config);
-    let service_rendered = service_params.render(template.as_ref().map(|p| p.as_ref()))?;
+    let template_path = template_path_str.as_ref().map(|t| PathBuf::from(t));
+    let service_rendered = service_params.render(template_path.as_ref().map(|t| t.as_ref()))?;
 
     let mut service_file = File::create(service_path)?;
     service_file.write_all(service_rendered.as_bytes())?;

--- a/cargo-rpm/src/license.rs
+++ b/cargo-rpm/src/license.rs
@@ -1,0 +1,162 @@
+//! Convert Cargo's SPDX 2.1 licenses to the format used by RPM's `License`
+//! field. RPM's valid licenses can be found in the "Short Name" column of
+//! the "Good Licenses" table from the Licensing page of the Fedora Project Wiki:
+//!
+//! <https://fedoraproject.org/wiki/Licensing:Main>
+
+#![allow(non_camel_case_types)]
+
+use failure::Error;
+
+/// Convert between an SPDX 2.1 license syntax and the RPM `License` field syntax
+pub fn convert(license_string: &str) -> Result<String, Error> {
+    let mut output = vec![];
+
+    if license_string.find("/").is_some() {
+        // Legacy syntax with '/' delimiter meaning "or"
+        for license in license_string.split("/") {
+            output.push(License::parse(license)?.as_rpm_str());
+        }
+
+        Ok(output.as_slice().join(" or "))
+    } else {
+        // Preferred syntax with "and"/"or" keywords
+        for token in license_string.split_whitespace() {
+            output.push(match token.to_lowercase().as_ref() {
+                "and" => "and",
+                "or" => "or",
+                other => License::parse(other)?.as_rpm_str(),
+            });
+        }
+
+        Ok(output.as_slice().join(" "))
+    }
+}
+
+/// Licenses for which we have a defined mapping between SPDX 2.1 labels and the
+/// RPM `License `field.
+pub enum License {
+    /// GNU Affero General Public License v3.0 only
+    /// <https://spdx.org/licenses/AGPL-3.0-only.html>
+    AGPL_3_0_ONLY, // AGPL-3.0-only
+
+    /// GNU Affero General Public License v3.0 or later
+    /// <https://spdx.org/licenses/AGPL-3.0-or-later.html>
+    AGPL_3_0_OR_LATER, // AGPL-3.0-or-later
+
+    /// Apache License 2.0
+    /// <https://spdx.org/licenses/Apache-2.0.html>
+    APACHE_2_0, // Apache-2.0
+
+    /// BSD 2-Clause "Simplified" License
+    /// <https://spdx.org/licenses/BSD-2-Clause.html>
+    BSD_2_CLAUSE, // BSD-2-Clause
+
+    /// BSD 3-Clause "New" or "Revised" License
+    /// <https://spdx.org/licenses/BSD-3-Clause.html>
+    BSD_3_CLAUSE, // BSD-3-Clause
+
+    /// Creative Commons Zero v1.0 Universal
+    /// <https://spdx.org/licenses/CC0-1.0.html>
+    CC0_1_0, // CC0-1.0
+
+    /// GNU General Public License v2.0 only
+    /// <https://spdx.org/licenses/GPL-2.0-only.html>
+    GPL_2_0_ONLY, // GPL-2.0-only
+
+    /// GNU General Public License v2.0 or later
+    /// <https://spdx.org/licenses/GPL-2.0-or-later.html>
+    GPL_2_0_OR_LATER, // GPL-2.0-or-later
+
+    /// GNU General Public License v3.0 only
+    /// <https://spdx.org/licenses/GPL-3.0-only.html>
+    GPL_3_0_ONLY, // GPL-3.0-only
+
+    /// GNU General Public License v3.0 or later
+    /// <https://spdx.org/licenses/GPL-3.0-or-later.html>
+    GPL_3_0_OR_LATER, // GPL-3.0-or-later
+
+    /// GNU Library General Public License v2 only
+    /// <https://spdx.org/licenses/LGPL-2.0-only.html>
+    LGPL_2_0_ONLY, // LGPL-2.0-only
+
+    /// GNU Library General Public License v2 or later
+    /// <https://spdx.org/licenses/LGPL-2.0-or-later.html>
+    LGPL_2_0_OR_LATER, // LGPL-2.0-or-later
+
+    /// GNU Lesser General Public License v2.1 only
+    /// <https://spdx.org/licenses/LGPL-2.1-only.html>
+    LGPL_2_1_ONLY, // LGPL-2.1-only
+
+    /// GNU Lesser General Public License v2.1 or later
+    /// <https://spdx.org/licenses/LGPL-2.1-or-later.html>
+    LGPL_2_1_OR_LATER, // LGPL-2.1-or-later
+
+    /// GNU Lesser General Public License v3.0 only
+    /// <https://spdx.org/licenses/LGPL-3.0-only.html>
+    LGPL_3_0_ONLY, // LGPL-3.0-only
+
+    /// GNU Lesser General Public License v3.0 or later
+    /// <https://spdx.org/licenses/LGPL-3.0-or-later.html>
+    LGPL_3_0_OR_LATER, // LGPL-3.0-or-later
+
+    /// MIT License
+    /// <https://spdx.org/licenses/MIT.html>
+    MIT, // MIT
+
+    /// Mozilla Public License 2.0
+    /// <https://spdx.org/licenses/MPL-2.0.html>
+    MPL_2_0, // MPL-2.0
+}
+
+impl License {
+    /// Parse a specific license into the `License` enum
+    pub fn parse(name: &str) -> Result<Self, Error> {
+        Ok(match name.to_owned().to_lowercase().as_ref() {
+            "agpl-3.0-only" => License::AGPL_3_0_ONLY,
+            "agpl-3.0-or-later" => License::AGPL_3_0_OR_LATER,
+            "apache-2.0" => License::APACHE_2_0,
+            "bsd-2-clause" => License::BSD_2_CLAUSE,
+            "bsd-3-clause" => License::BSD_3_CLAUSE,
+            "cc0-1.0" => License::CC0_1_0,
+            "gpl-2.0-only" => License::GPL_2_0_ONLY,
+            "gpl-2.0-or-later" => License::GPL_2_0_OR_LATER,
+            "gpl-3.0-only" => License::GPL_3_0_ONLY,
+            "gpl-3.0-or-later" => License::GPL_3_0_OR_LATER,
+            "lgpl-2.0-only" => License::LGPL_2_0_ONLY,
+            "lgpl-2.0-or-later" => License::LGPL_2_0_OR_LATER,
+            "lgpl-2.1-only" => License::LGPL_2_1_ONLY,
+            "lgpl-2.1-or-later" => License::LGPL_2_1_OR_LATER,
+            "lgpl-3.0-only" => License::LGPL_3_0_ONLY,
+            "lgpl-3.0-or-later" => License::LGPL_3_0_OR_LATER,
+            "mit" => License::MIT,
+            "mpl-2.0" => License::MPL_2_0,
+            _ => bail!("unknown license: {:?}", name),
+        })
+    }
+
+    /// Return a license name from the Fedora Licenses table:
+    /// <https://fedoraproject.org/wiki/Licensing:Main>
+    pub fn as_rpm_str(&self) -> &'static str {
+        match *self {
+            License::AGPL_3_0_ONLY => "AGPLv3",
+            License::AGPL_3_0_OR_LATER => "AGPLv3+",
+            License::APACHE_2_0 => "ASL 2.0",
+            License::BSD_2_CLAUSE => "BSD",
+            License::BSD_3_CLAUSE => "BSD",
+            License::CC0_1_0 => "CC0",
+            License::GPL_2_0_ONLY => "GPLv2",
+            License::GPL_2_0_OR_LATER => "GPLv2+",
+            License::GPL_3_0_ONLY => "GPLv3",
+            License::GPL_3_0_OR_LATER => "GPLv3+",
+            License::LGPL_2_0_ONLY => "LGPLv2",
+            License::LGPL_2_0_OR_LATER => "LGPLv2+",
+            License::LGPL_2_1_ONLY => "LGPLv2",
+            License::LGPL_2_1_OR_LATER => "LGPLv2+",
+            License::LGPL_3_0_ONLY => "LGPLv3",
+            License::LGPL_3_0_OR_LATER => "LGPLv3+",
+            License::MIT => "MIT",
+            License::MPL_2_0 => "MPLv2.0",
+        }
+    }
+}

--- a/cargo-rpm/src/main.rs
+++ b/cargo-rpm/src/main.rs
@@ -1,0 +1,99 @@
+//! cargo-rpm: Cargo subcommand for creating RPM releases of Rust projects
+
+#[macro_use]
+extern crate failure;
+extern crate gumdrop;
+#[macro_use]
+extern crate gumdrop_derive;
+extern crate handlebars;
+extern crate iq_cli;
+#[macro_use]
+extern crate lazy_static;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate toml;
+
+/// Cargo.toml parser
+pub mod cargo_config;
+
+/// License format converter
+pub mod license;
+
+/// The `cargo rpm init` subcommand
+pub mod init;
+
+/// Shell support (for printing status messages)
+pub mod shell;
+
+/// Target type autodetection for crates
+pub mod target;
+
+/// Handlebars templates (for RPM specs, etc)
+pub mod templates;
+
+/// Subdirectory of a Rust project in which we keep RPM-related configs
+pub const RPM_CONFIG_DIR: &str = ".rpm";
+
+use gumdrop::Options;
+use std::env;
+use std::process::exit;
+
+use init::InitOpts;
+
+/// Command line arguments (parsed by gumdrop)
+#[derive(Debug, Options)]
+enum Opts {
+    #[options(help = "Build RPMs from Rust projects using Cargo")]
+    Rpm(RpmOpts),
+}
+
+/// Options for the `cargo rpm` subcommand
+#[derive(Debug, Options)]
+enum RpmOpts {
+    #[options(help = "Show help for a command")]
+    Help(HelpOpts),
+
+    #[options(help = "Initialize a Rust project with RPM support")]
+    Init(InitOpts),
+}
+
+/// Options for the `help` command
+#[derive(Debug, Default, Options)]
+struct HelpOpts {
+    #[options(free)]
+    free: Vec<String>,
+}
+
+/// Main entry point
+fn main() {
+    let args: Vec<_> = env::args().collect();
+
+    let Opts::Rpm(rpm_opts) = Opts::parse_args_default(&args[1..]).unwrap_or_else(|e| {
+        match e.to_string().as_ref() {
+            // Show usage if no command name is given or if "help" is given
+            "missing command name" => help(),
+            string => eprintln!("{}: {}", args[0], string),
+        }
+
+        exit(2);
+    });
+
+    match rpm_opts {
+        RpmOpts::Help(_commands) => help(),
+        RpmOpts::Init(init) => init.call(),
+    }.unwrap_or_else(|e| shell::exit_error(e));
+
+    exit(0);
+}
+
+/// Print help message
+fn help() -> ! {
+    println!("Usage: cargo rpm [COMMAND] [OPTIONS]");
+    println!();
+    println!("Available commands:");
+    println!();
+    println!("{}", RpmOpts::command_list().unwrap());
+    println!();
+    exit(2);
+}

--- a/cargo-rpm/src/shell.rs
+++ b/cargo-rpm/src/shell.rs
@@ -1,0 +1,40 @@
+//! Shell support bindings
+
+use iq_cli::{self, Color, ColorConfig, Shell};
+pub use iq_cli::color;
+use std::fmt;
+use std::process;
+use std::sync::Mutex;
+
+lazy_static! {
+    static ref SHELL: Mutex<Shell> = Mutex::new(iq_cli::create_shell(ColorConfig::Auto));
+}
+
+/// Say something with the given color
+pub fn say<T: ToString>(message: &T, color: Color) {
+    SHELL.lock().unwrap().say(message, color).unwrap();
+}
+
+/// Say a status message with the given color
+pub fn say_status<T, U>(status: T, message: U, color: Color, justified: bool)
+where
+    T: fmt::Display,
+    U: fmt::Display,
+{
+    SHELL
+        .lock()
+        .unwrap()
+        .say_status(status, message, color, justified)
+        .unwrap();
+}
+
+/// Print a warning message
+pub fn warning<T: fmt::Display>(msg: T) {
+    say_status("warning:", msg, color::YELLOW, false);
+}
+
+/// Print the given error message to the shell and exit
+pub fn exit_error<T: fmt::Display>(msg: T) -> ! {
+    say_status("error:", msg, color::RED, false);
+    process::exit(1);
+}

--- a/cargo-rpm/src/target.rs
+++ b/cargo-rpm/src/target.rs
@@ -1,0 +1,48 @@
+//! Target-type autodetection for crates
+
+use failure::Error;
+use std::fs;
+use std::path::Path;
+
+/// Target types we can autodetect
+pub enum TargetType {
+    /// Library crate i.e. `lib.rs` (we don't support these yet)
+    Lib,
+
+    /// Binary crate with a single executable i.e. `main.rs`
+    Bin,
+
+    /// Crate with multiple binary targets i.e. `src/bin/*.rs`
+    /// (we don't support these yet)
+    MultiBin(Vec<String>),
+}
+
+impl TargetType {
+    /// Autodetect the targets for this crate
+    pub fn detect(base_path: &Path) -> Result<Self, Error> {
+        if base_path.join("src/bin").exists() {
+            let mut bins = vec![];
+
+            for bin in fs::read_dir(base_path.join("src/bin"))? {
+                let mut bin_str = bin?.path().display().to_string();
+
+                if !bin_str.ends_with(".rs") {
+                    bail!("unrecognized file in src/bin: {:?}", bin_str);
+                }
+
+                // Remove .rs extension
+                let new_len = bin_str.len() - 3;
+                bin_str.truncate(new_len);
+                bins.push(bin_str);
+            }
+
+            Ok(TargetType::MultiBin(bins))
+        } else if base_path.join("src/main.rs").exists() {
+            Ok(TargetType::Bin)
+        } else if base_path.join("src/lib.rs").exists() {
+            Ok(TargetType::Lib)
+        } else {
+            bail!("couldn't detect crate type (no main.rs or lib.rs?)");
+        }
+    }
+}

--- a/cargo-rpm/src/templates.rs
+++ b/cargo-rpm/src/templates.rs
@@ -1,0 +1,124 @@
+//! Handlebars templates (for RPM specs, etc)
+
+use failure::Error;
+use handlebars::Handlebars;
+use serde::Serialize;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use cargo_config::PackageConfig;
+use license;
+use shell;
+
+/// Default RPM spec template (in toplevel `template/spec.hbs`)
+pub const DEFAULT_SPEC_TEMPLATE: &str = include_str!("../templates/spec.hbs");
+
+/// Default systemd service unit template (in toplevel `template/service.hbs`)
+pub const DEFAULT_SERVICE_TEMPLATE: &str = include_str!("../templates/service.hbs");
+
+/// Parameters passed to the RPM spec template
+#[derive(Serialize)]
+pub struct SpecParams {
+    /// Name of the RPM, sans ".rpm", e.g. "ripgrep"
+    pub name: String,
+
+    /// Description of the RPM
+    pub summary: String,
+
+    /// License of the *binary* contents of the RPM
+    pub license: Option<String>,
+
+    /// URL to a home page for this package
+    pub url: Option<String>,
+
+    /// Name of a systemd service unit (if enabled)
+    pub service: Option<String>,
+}
+
+impl SpecParams {
+    /// Render an RPM spec template at the given path (or default)
+    pub fn render(&self, template_path: Option<&Path>) -> Result<String, Error> {
+        let name = match template_path {
+            Some(p) => p.display().to_string(),
+            None => "(default:spec.hbs)".to_owned(),
+        };
+
+        let template = load_template(template_path, DEFAULT_SPEC_TEMPLATE)?;
+        render_template(&name, &template, self)
+    }
+}
+
+impl<'a> From<&'a PackageConfig> for SpecParams {
+    fn from(package: &'a PackageConfig) -> Self {
+        let rpm_license = package.license.as_ref().map(|spdx_license| {
+            license::convert(spdx_license).unwrap_or_else(|e| {
+                shell::warning(format!("couldn't parse license {:?}: {}", spdx_license, e));
+                spdx_license.to_owned()
+            })
+        });
+
+        Self {
+            name: package.name.to_owned(),
+            summary: package.description.to_owned(),
+            license: rpm_license,
+            url: package.homepage.to_owned(),
+            service: None,
+        }
+    }
+}
+
+/// Paramters passed to the systemd service unit template
+#[derive(Serialize)]
+pub struct ServiceParams {
+    /// Description of the service
+    pub description: String,
+
+    /// Path to the binary for systemd to spawn (absolute)
+    pub bin_path: PathBuf,
+}
+
+impl ServiceParams {
+    /// Render a systemd service unit template at the given path (or default)
+    pub fn render(&self, template_path: Option<&Path>) -> Result<String, Error> {
+        let name = match template_path {
+            Some(p) => p.display().to_string(),
+            None => "(default:service.hbs)".to_owned(),
+        };
+
+        let template = load_template(template_path, DEFAULT_SERVICE_TEMPLATE)?;
+        render_template(&name, &template, self)
+    }
+}
+
+impl<'a> From<&'a PackageConfig> for ServiceParams {
+    fn from(package: &'a PackageConfig) -> Self {
+        Self {
+            description: package.description.to_owned(),
+            /// TODO: better handling of target binaries and their paths
+            bin_path: PathBuf::from("/usr/sbin").join(&package.name),
+        }
+    }
+}
+
+/// Load a template
+fn load_template(template_path: Option<&Path>, default_template: &str) -> Result<String, Error> {
+    match template_path {
+        Some(p) => {
+            let mut file = File::open(p)?;
+            let mut s = String::new();
+            file.read_to_string(&mut s)?;
+            Ok(s)
+        }
+        None => Ok(default_template.to_owned()),
+    }
+}
+
+/// Render a template
+fn render_template<T: Serialize>(name: &str, template: &str, data: &T) -> Result<String, Error> {
+    let mut handlebars = Handlebars::new();
+    handlebars.register_template_string(name, template).unwrap();
+    handlebars
+        .render(name, data)
+        .map_err(|e| format_err!("Error rendering template: {}", e))
+}

--- a/cargo-rpm/templates/README.md
+++ b/cargo-rpm/templates/README.md
@@ -1,0 +1,11 @@
+# RPM Spec Templates
+
+This directory contains [Handlebars] templates of files we use when building
+RPMs:
+
+* `spec.hbs`: An [RPM Spec File] generated using metadata from `Cargo.toml`
+* `service.hbs`: a [systemd service unit configuration] file (optional)
+
+[Handlebars]: https://github.com/sunng87/handlebars-rust
+[RPM Spec File]: https://rpm-guide.readthedocs.io/en/latest/rpm-guide.html#what-is-a-spec-file
+[systemd service unit configuration]: https://fedoramagazine.org/systemd-getting-a-grip-on-units/

--- a/cargo-rpm/templates/service.hbs
+++ b/cargo-rpm/templates/service.hbs
@@ -1,0 +1,12 @@
+[Unit]
+Description={{ description }}
+After=network.target
+
+[Service]
+Type=simple
+ExecStart={{ bin_path }}
+KillMode=process
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/cargo-rpm/templates/spec.hbs
+++ b/cargo-rpm/templates/spec.hbs
@@ -1,0 +1,66 @@
+%define __spec_install_post %{nil}
+%define __os_install_post %{_dbpath}/brp-compress
+%define debug_package %{nil}
+
+Name: {{ name }}
+Summary: {{ summary }}
+Version: @@VERSION@@ # Set automatically by "cargo rpm build"
+Release: 1
+{{#if license ~}}
+License: {{ license }}
+{{/if ~}}
+{{#if service ~}}
+Group: System Environment/Daemons
+{{else ~}}
+Group: Applications/System
+{{/if ~}}
+Source0: %{name}-%{version}.tar.gz
+{{#if url ~}}
+URL: {{ url }}
+{{/if}}
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+{{#if service ~}}
+BuildRequires: systemd
+
+Requires(post): systemd
+Requires(preun): systemd
+Requires(postun): systemd
+{{/if}}
+%description
+%{summary}
+
+%prep
+%setup -q
+
+%build
+# Empty section.
+
+%install
+rm -rf %{buildroot}
+mkdir -p  %{buildroot}
+
+# in builddir
+cp -a * %{buildroot}
+
+%clean
+rm -rf %{buildroot}
+
+{{#if service ~}}
+%systemd_post {{service}}
+
+%preun
+%systemd_preun {{service}}
+
+%postun
+%systemd_postun_with_restart {{service}}
+
+{{/if ~}}
+
+%files
+%defattr(-,root,root,-)
+%config(noreplace) %{_sysconfdir}/*
+${_bindir}/*
+%{_sbindir}/*
+{{#if service ~}}
+%{_unitdir}/{{service}}
+{{/if ~}}

--- a/iq-cli/src/lib.rs
+++ b/iq-cli/src/lib.rs
@@ -10,6 +10,26 @@ extern crate term;
 
 mod shell;
 
-pub use shell::{create, ColorConfig, Shell, ShellConfig};
+pub use shell::{ColorConfig, Shell, ShellConfig};
 pub use term::color;
 pub use term::color::Color;
+
+use std::io;
+use libc::isatty;
+
+/// Create a new shell
+pub fn create_shell(color_config: ColorConfig) -> Shell {
+    let config = ShellConfig {
+        color_config,
+        tty: is_tty(),
+    };
+    Shell::create(|| Box::new(io::stdout()), config)
+}
+
+/// Is STDOUT a tty?
+fn is_tty() -> bool {
+    #[allow(unsafe_code)]
+    unsafe {
+        isatty(0) == 1
+    }
+}

--- a/iq-cli/src/shell.rs
+++ b/iq-cli/src/shell.rs
@@ -2,30 +2,12 @@
 //!
 //! Portions of this code are borrowed from Cargo
 
-use libc::isatty;
 use std::fmt;
 use std::io;
 use std::io::prelude::*;
 use term::{self, Attr, TerminfoTerminal};
 use term::Terminal as RawTerminal;
 use term::color::{Color, BLACK};
-
-/// Is STDOUT a tty?
-pub(crate) fn is_tty() -> bool {
-    #[allow(unsafe_code)]
-    unsafe {
-        isatty(0) == 1
-    }
-}
-
-/// Create a new shell
-pub fn create(color_config: ColorConfig) -> Shell {
-    let config = ShellConfig {
-        color_config,
-        tty: is_tty(),
-    };
-    Shell::create(|| Box::new(io::stdout()), config)
-}
 
 /// Color configuration
 #[derive(Clone, Copy, PartialEq)]


### PR DESCRIPTION
Adds a "cargo rpm" subcommand which builds RPM releases of Rust projects.

Well... not just yet, but "cargo rpm build" will do that, and this PR was already getting pretty unwieldy.

In an act of inception, this project is already "cargo rpm init"-ed.