### PR TITLE
Respect the CARGO_TARGET_DIR environment var, if set

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,3 +10,4 @@ contributions under the terms of the [Apache License, Version 2.0]
 
 * Anthony Arcieri ([@tarcieri](https://github.com/tarcieri))
 * Yin Guanhao ([@sopium](https://github.com/sopium))
+* Josh Huber ([@uberjay](https://github.com/uberjay))

--- a/cargo-rpm/src/target.rs
+++ b/cargo-rpm/src/target.rs
@@ -1,11 +1,17 @@
 //! Target-type autodetection for crates
 
 use failure::Error;
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 /// Locate the project's target directory
 pub fn find_dir() -> Result<PathBuf, Error> {
+    // Allow for an explicit override of the target directory.
+    if let Some(p) = env::var_os("CARGO_TARGET_DIR") {
+        return Ok(PathBuf::from(p));
+    }
+
     // Check all parents of the current directory for a target directory.
     // We could call `cargo metadata` to find it but this is much cheaper.
     let mut path = fs::canonicalize(".")?;


### PR DESCRIPTION
Simple change, and makes cargo-rpm match cargo's own behavior.